### PR TITLE
Updating email address for CoC

### DIFF
--- a/3._Notices.md
+++ b/3._Notices.md
@@ -53,6 +53,6 @@ This section includes any Exclusion Notices made against a Draft Deliverable or 
 
 Contact for Code of Conduct issues or inquires:
 * Kate Stewart (kstewart@linuxfoundation.org)
-* Steve Winslow (swinslow@linuxfoundation.org)
+* Steve Winslow (steve@swinslow.net)
 * Jilayne Lovejoy (opensource@jilayne.com)
 


### PR DESCRIPTION
Signed-off-by: Steve Winslow <steve@swinslow.net>