### PR TITLE
Clarified when number of team leads can be reduced

### DIFF
--- a/5._Governance.md
+++ b/5._Governance.md
@@ -49,7 +49,7 @@ During the initial year, the Steering Committee will group the Team Leads and Ch
 
 At the expiration of a Team Lead term, any Participant may submit a nomination for a Team Lead role. 
 
-If a Team Lead or the Chair resigns or ceases to participate prior to the end of their term, the Steering Committee will determine whether and when to fill the role.
+At the expiration of a Team Lead term, or if a Team Lead or the Chair resigns or ceases to participate prior to the end of their term, the Steering Committee will determine whether and when to fill the role.
 
 The Steering Committee may add additional Team Leads as it deems necessary up to the maximum number of Team Leads for a Team as stated above. 
 


### PR DESCRIPTION
`2.6` provided for increasing the number of team leads, but it only allowed reducing it when a team lead resigns or ceases to participate. Expanded the language to allow the Steering Committee to also be able to reduce it at the end of the team lead's term.

Passed by voice vote during the 2023-01-24 Steering Committee meeting as described in the minutes.