### PR TITLE
Update scope for SPDX 3.0.1

### DIFF
--- a/2._Scope.md
+++ b/2._Scope.md
@@ -1,18 +1,19 @@
 # Scope
 
-The Software Package Data Exchange (SPDX) specification defines an open standard for communicating software bill of material (SBOM) information.
+The System Package Data Exchange (SPDX) specification defines an open standard for communicating bill of material (BOM) information for different topic areas.
 
 SPDX defines an underlying data model as well as multiple serialization formats to encode that data model.
 
-SPDX metadata includes details about software creation and distribution, including the following:
+SPDX metadata includes details about creation and distribution, including the following:
+
 * software composition, for collections of software (Packages), individual Files, and portions of files (Snippets)
 * software build information
+* artificial intelligence (AI) models
+* datasets
 * creator, supplier and distributor identity information
 * provenance and integrity
 * licenses and copyrights, including a curated list of licenses and exceptions
 * security vulnerabilities, defects, and other quality data
-* relationships between software elements
+* relationships between system elements
 * software usage and lifecycle
 * mechanisms to enable annotating SPDX elements and linking between multiple SPDX Documents
-
-Any changes of Scope are not retroactive.


### PR DESCRIPTION
This PR updates the [Scope document](https://github.com/spdx/governance/blob/main/2._Scope.md) with some applicable changes in preparation for SPDX 3.0.1.

For SPDX 3.0.1 and future versions, the corresponding "scope" page in the published spec would be aligned with using a then-current copy of this Scope file's contents.

Because of that planned change, this PR also removes the "Any changes of Scope are not retroactive." line from the end of the file. Personally I don't think this line is essential, since Section 9.13 of [Community-Spec-1.0](https://github.com/spdx/governance/blob/main/1._Community_Specification_License-v1.md) also explicitly defines "Scope" to indicate that "Changes to Scope do not apply retroactively."

Fixes #12 

Signed-off-by: Steve Winslow <steve@swinslow.net>